### PR TITLE
Add k8s configs

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -17,7 +17,12 @@
         // while, and we want to minimize waiting during `git commit`
         "Initialize pre-commit environment": "nohup sh -c 'pre-commit install -f --install-hooks &' < /dev/null > /dev/null 2>&1",
         "Install kustomize": "go install sigs.k8s.io/kustomize/kustomize/v5@latest",
-        "Install kubectl": "curl -sL -o /tmp/kubectl \"https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl\" && sudo install /tmp/kubectl /usr/local/bin",
-        "Install oc": "curl -sL -o /tmp/oc.tar.gz \"https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/latest/openshift-client-linux.tar.gz\" && tar -xzf /tmp/oc.tar.gz -C /tmp && sudo install /tmp/oc /usr/local/bin"
+        "Install kubectl": "curl -sL -o /tmp/kubectl \"https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl\" && \
+                            sudo install /tmp/kubectl /usr/local/bin",
+        "Install oc": "curl -sL -o /tmp/oc.tar.gz \"https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/latest/openshift-client-linux.tar.gz\" && \
+                       tar -xzf /tmp/oc.tar.gz -C /tmp && \
+                       sudo install /tmp/oc /usr/local/bin",
+            "Install packages": "sudo apt-get update && \
+                                 sudo apt-get install -y --no-install-recommends xdg-utils"
     }
 }

--- a/.github/yamllint-config.yaml
+++ b/.github/yamllint-config.yaml
@@ -15,7 +15,6 @@ rules:
       .github/workflows/*
   indentation:
     indent-sequences: consistent
-  line-length:
-    allow-non-breakable-inline-mappings: true
+  line-length: disable
   new-lines:
     type: platform

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .env
+/deploy/augur-secret.yaml

--- a/bases/augur/backend/augur-deployment.yaml
+++ b/bases/augur/backend/augur-deployment.yaml
@@ -1,0 +1,73 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: augur
+spec:
+  replicas: 1
+  template:
+    spec:
+      containers:
+        - name: augur
+          image: ghcr.io/chaoss/augur_backend
+          env:
+            - name: AUGUR_DB
+              value: "postgresql+psycopg2://augur:augur@augur-db:5432/augur"  # pragma: allowlist secret
+            - name: AUGUR_DB_SCHEMA_BUILD
+              value: "1"
+            - name: AUGUR_FACADE_REPO_DIRECTORY
+              value: "/facade"
+            - name: AUGUR_GITHUB_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: augur-secret
+                  key: AUGUR_GITHUB_API_KEY
+            - name: AUGUR_GITLAB_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: augur-secret
+                  key: AUGUR_GITLAB_API_KEY
+            - name: AUGUR_GITHUB_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: augur-secret
+                  key: AUGUR_GITHUB_USERNAME
+            - name: AUGUR_GITLAB_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: augur-secret
+                  key: AUGUR_GITLAB_USERNAME
+            - name: REDIS_CONN_STRING
+              value: "redis://redis:6379"
+            - name: RABBITMQ_CONN_STRING
+              value: "amqp://augur:password123@rabbitmq:5672/augur_vhost"  # pragma: allowlist secret
+            - name: CONFIG_LOCATION
+              value: "/config/config.yml"
+            - name: CACHE_DATADIR
+              value: "/cache"
+            - name: CACHE_LOCKDIR
+              value: "/cache"
+            - name: CELERYBEAT_SCHEDULE_DB
+              value: "/tmp/celerybeat-schedule.db"
+          ports:
+            - containerPort: 5000
+          volumeMounts:
+            - mountPath: /cache
+              name: cache
+            - mountPath: /config
+              name: config
+            - mountPath: /facade
+              name: facade
+            - mountPath: /logs
+              name: logs
+      volumes:
+        - name: cache
+          emptyDir: {}
+        - name: config
+          persistentVolumeClaim:
+            claimName: augur-config-pvc
+        - name: facade
+          persistentVolumeClaim:
+            claimName: facade-pvc
+        - name: logs
+          emptyDir: {}

--- a/bases/augur/backend/augur-svc.yaml
+++ b/bases/augur/backend/augur-svc.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: augur
+spec:
+  ports:
+    - protocol: TCP
+      port: 5002
+      targetPort: 5000
+  type: ClusterIP

--- a/bases/augur/backend/config-pvc.yaml
+++ b/bases/augur/backend/config-pvc.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: augur-config-pvc
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 100Mi

--- a/bases/augur/backend/facade-pvc.yaml
+++ b/bases/augur/backend/facade-pvc.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: facade-pvc
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 5Gi

--- a/bases/augur/backend/kustomization.yaml
+++ b/bases/augur/backend/kustomization.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - augur-deployment.yaml
+  - augur-svc.yaml
+  - config-pvc.yaml
+  - facade-pvc.yaml
+
+labels:
+  - includeSelectors: true
+    pairs:
+      app.kubernetes.io/component: backend
+      app.kubernetes.io/name: augur-backend

--- a/bases/augur/flower/flower-deployment.yaml
+++ b/bases/augur/flower/flower-deployment.yaml
@@ -1,0 +1,27 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: flower
+spec:
+  replicas: 1
+  template:
+    spec:
+      containers:
+        - name: flower
+          image: ghcr.io/chaoss/augur_backend
+          args:
+            - "celery"
+            - "-A"
+            - "augur.tasks.init.celery_app.celery_app"
+            - "flower"
+            - "--max-tasks=1000000"
+          env:
+            - name: AUGUR_DB
+              value: "postgresql+psycopg2://augur:augur@augur-db:5432/augur"  # pragma: allowlist secret
+            - name: REDIS_CONN_STRING
+              value: "redis://redis:6379"
+            - name: RABBITMQ_CONN_STRING
+              value: "amqp://augur:password123@rabbitmq:5672/augur_vhost"  # pragma: allowlist secret
+          ports:
+            - containerPort: 5555

--- a/bases/augur/flower/flower-svc.yaml
+++ b/bases/augur/flower/flower-svc.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  # Can't name this "flower" because it causes an env var to be set in the
+  # flower pod that causes it to fail
+  name: flower-dashboard
+spec:
+  ports:
+    - protocol: TCP
+      port: 5555
+      targetPort: 5555
+  type: ClusterIP

--- a/bases/augur/flower/kustomization.yaml
+++ b/bases/augur/flower/kustomization.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - flower-deployment.yaml
+  - flower-svc.yaml
+
+labels:
+  - includeSelectors: true
+    pairs:
+      app.kubernetes.io/component: dashboard
+      app.kubernetes.io/name: flower

--- a/bases/augur/keyman/keyman-deployment.yaml
+++ b/bases/augur/keyman/keyman-deployment.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: keyman
+spec:
+  replicas: 1
+  selector:
+  strategy:
+    type: RollingUpdate
+  template:
+    spec:
+      containers:
+        - name: keyman
+          image: ghcr.io/chaoss/augur_keyman:latest
+          env:
+            - name: REDIS_CONN_STRING
+              value: "redis://redis:6379"

--- a/bases/augur/keyman/kustomization.yaml
+++ b/bases/augur/keyman/kustomization.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - keyman-deployment.yaml
+
+labels:
+  - includeSelectors: true
+    pairs:
+      app.kubernetes.io/component: key-manager
+      app.kubernetes.io/name: keyman

--- a/bases/augur/kustomization.yaml
+++ b/bases/augur/kustomization.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - backend
+  - flower
+  - keyman
+  - postgres
+  - rabbitmq
+  - redis
+
+labels:
+  - includeSelectors: true
+    pairs:
+      app.kubernetes.io/part-of: augur

--- a/bases/augur/postgres/augur-db-secret.yaml
+++ b/bases/augur/postgres/augur-db-secret.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: augur-db-secret
+type: Opaque
+stringData:
+  AUGUR_DB_USER: "augur"
+  AUGUR_DB_PASSWORD: "augur"  # pragma: allowlist secret

--- a/bases/augur/postgres/kustomization.yaml
+++ b/bases/augur/postgres/kustomization.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - augur-db-secret.yaml
+  - postgres-deployment.yaml
+  - postgres-pvc.yaml
+  - postgres-svc.yaml
+
+labels:
+  - includeSelectors: true
+    pairs:
+      app.kubernetes.io/component: database
+      app.kubernetes.io/name: postgres

--- a/bases/augur/postgres/postgres-deployment.yaml
+++ b/bases/augur/postgres/postgres-deployment.yaml
@@ -1,0 +1,37 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: postgres
+spec:
+  replicas: 1
+  selector:
+  template:
+    spec:
+      containers:
+        - name: augur-db
+          image: postgres:16
+          env:
+            - name: POSTGRES_DB
+              value: "augur"
+            - name: POSTGRES_USER
+              valueFrom:
+                secretKeyRef:
+                  name: augur-db-secret
+                  key: AUGUR_DB_USER
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: augur-db-secret
+                  key: AUGUR_DB_PASSWORD
+            - name: PGDATA
+              value: "/var/lib/postgresql/data/pgdata"
+          ports:
+            - containerPort: 5432
+          volumeMounts:
+            - mountPath: /var/lib/postgresql/data
+              name: augurpostgres
+      volumes:
+        - name: augurpostgres
+          persistentVolumeClaim:
+            claimName: postgres

--- a/bases/augur/postgres/postgres-pvc.yaml
+++ b/bases/augur/postgres/postgres-pvc.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: postgres
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi

--- a/bases/augur/postgres/postgres-svc.yaml
+++ b/bases/augur/postgres/postgres-svc.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: augur-db
+spec:
+  selector:
+  ports:
+    - protocol: TCP
+      port: 5432
+      targetPort: 5432
+  type: ClusterIP

--- a/bases/augur/rabbitmq/kustomization.yaml
+++ b/bases/augur/rabbitmq/kustomization.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - rabbitmq-config-secret.yaml
+  - rabbitmq-sts.yaml
+  - rabbitmq-svc.yaml
+
+labels:
+  - includeSelectors: true
+    pairs:
+      app.kubernetes.io/component: message-queue
+      app.kubernetes.io/name: rabbitmq

--- a/bases/augur/rabbitmq/rabbitmq-config-secret.yaml
+++ b/bases/augur/rabbitmq/rabbitmq-config-secret.yaml
@@ -1,0 +1,30 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: rabbitmq-config
+type: Opaque
+stringData:
+  # https://github.com/rabbitmq/rabbitmq-server/blob/v4.0.x/deps/rabbit/docs/rabbitmq.conf.example
+  rabbitmq.conf: |
+    default_vhost = augur_vhost
+    default_user = augur
+    default_pass = password123
+    default_permissions.configure = .*
+    default_permissions.read = .*
+    default_permissions.write = .*
+    default_user_tags.administrator = true
+    default_user_tags.augur = true
+    default_user_tags.augurTag = true
+    vm_memory_high_watermark.absolute = 1GB
+
+    # Clustering
+    cluster_name = augur.local
+    cluster_formation.peer_discovery_backend = classic_config
+    cluster_formation.classic_config.nodes.1 = rabbit@rabbitmq-0
+
+    # Max time a consumer can take to ack a message before the connection is
+    # force closed
+    consumer_timeout = 900000
+    log.console = true
+    log.file = false

--- a/bases/augur/rabbitmq/rabbitmq-sts.yaml
+++ b/bases/augur/rabbitmq/rabbitmq-sts.yaml
@@ -1,0 +1,45 @@
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: rabbitmq
+spec:
+  serviceName: rabbitmq
+  replicas: 1
+  template:
+    spec:
+      containers:
+        - name: rabbitmq
+          image: rabbitmq:3.12-management-alpine
+          # Setting node name isn't necessary since the StatefulSet will use
+          # predictable names (rabbitmq-0, rabbitmq-1, etc.)
+          # env:
+          #   - name: RABBITMQ_NODE_NAME
+          #     valueFrom:
+          #       fieldRef:
+          #         fieldPath: metadata.name
+          ports:
+            - containerPort: 5671   # AMQP 0-9-1 and 1.0 over SSL
+            - containerPort: 5672   # AMQP 0-9-1 and 1.0
+            - containerPort: 15671  # Management UI over SSL
+            - containerPort: 15672  # Management UI
+          volumeMounts:
+            - name: rabbitmq-data
+              mountPath: /var/lib/rabbitmq/mnesia
+            - name: rabbitmq-config
+              mountPath: /etc/rabbitmq
+      volumes:
+        - name: rabbitmq-config
+          secret:
+            secretName: rabbitmq-config  # pragma: allowlist secret
+  statefulSetPersistentVolumeClaimRetentionPolicy:
+    whenDeleted: Delete
+    whenScaled: Retain
+  volumeClaimTemplates:
+    - metadata:
+        name: rabbitmq-data
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        resources:
+          requests:
+            storage: 1Gi

--- a/bases/augur/rabbitmq/rabbitmq-svc.yaml
+++ b/bases/augur/rabbitmq/rabbitmq-svc.yaml
@@ -1,0 +1,24 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: rabbitmq
+spec:
+  ports:
+    - name: amqp-ssl
+      protocol: TCP
+      port: 5671
+      targetPort: 5671
+    - name: amqp
+      protocol: TCP
+      port: 5672
+      targetPort: 5672
+    - name: management-ssl
+      protocol: TCP
+      port: 15671
+      targetPort: 15671
+    - name: management
+      protocol: TCP
+      port: 15672
+      targetPort: 15672
+  type: ClusterIP

--- a/bases/augur/redis/kustomization.yaml
+++ b/bases/augur/redis/kustomization.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - redis-data-pvc.yaml
+  - redis-deployment.yaml
+  - redis-svc.yaml
+
+labels:
+  - includeSelectors: true
+    pairs:
+      app.kubernetes.io/component: redis
+      app.kubernetes.io/name: redis

--- a/bases/augur/redis/redis-data-pvc.yaml
+++ b/bases/augur/redis/redis-data-pvc.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: redis-data
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi

--- a/bases/augur/redis/redis-deployment.yaml
+++ b/bases/augur/redis/redis-deployment.yaml
@@ -1,0 +1,27 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: redis
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: redis
+  template:
+    metadata:
+      labels:
+        app: redis
+    spec:
+      containers:
+        - name: redis
+          image: redis:alpine
+          ports:
+            - containerPort: 6379
+          volumeMounts:
+            - mountPath: /data
+              name: redis-data
+      volumes:
+        - name: redis-data
+          persistentVolumeClaim:
+            claimName: redis-data

--- a/bases/augur/redis/redis-svc.yaml
+++ b/bases/augur/redis/redis-svc.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: redis
+spec:
+  selector:
+    app: redis
+  ports:
+    - protocol: TCP
+      port: 6379
+      targetPort: 6379
+  type: ClusterIP

--- a/bases/kustomization.yaml
+++ b/bases/kustomization.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - augur
+
+buildMetadata:
+  - originAnnotations
+  - transformerAnnotations

--- a/deploy/kustomization.yaml
+++ b/deploy/kustomization.yaml
@@ -1,0 +1,25 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../bases
+  # Secret containing GitHub and GitLab tokens (not checked in)
+  # Needs to contain:
+  # - AUGUR_GITHUB_USERNAME
+  # - AUGUR_GITHUB_API_KEY
+  # - AUGUR_GITLAB_USERNAME
+  # - AUGUR_GITLAB_API_KEY
+  - augur-secret.yaml
+
+# Namespace for deployment
+namespace: augur-on-ocp
+
+# Mappings for the augur-specific images used in the deployment
+images:
+  - name: ghcr.io/chaoss/augur_backend
+    newName: johnstrunk/augur-backend
+    newTag: latest
+  - name: ghcr.io/chaoss/augur_keyman
+    newName: johnstrunk/augur-keyman
+    newTag: latest

--- a/hack/login-cluster.sh
+++ b/hack/login-cluster.sh
@@ -1,0 +1,4 @@
+#! /bin/bash
+
+# oc login --web --server=https://api.cairo.test.nerc.mghpcc.org:6443
+oc login --web --server=https://api.platform-sts.pcbk.p1.openshiftapps.com:6443


### PR DESCRIPTION
This pull request introduces several changes to enhance Kubernetes deployment configurations, improve linting rules, and update the development container setup. The most significant updates include the addition of Kubernetes manifests for various components of the `augur` application, modifications to YAML linting rules, and updates to the `.devcontainer` configuration.

### Kubernetes Deployment Enhancements:
* Added deployment, service, and persistent volume claim manifests for the `augur` backend, including components like `flower`, `keyman`, `postgres`, and `rabbitmq` to facilitate Kubernetes-based deployments. (`bases/augur/backend/augur-deployment.yaml`, `bases/augur/backend/augur-svc.yaml`, `bases/augur/backend/config-pvc.yaml`, `bases/augur/backend/facade-pvc.yaml`, `bases/augur/flower/flower-deployment.yaml`, `bases/augur/flower/flower-svc.yaml`, `bases/augur/keyman/keyman-deployment.yaml`, `bases/augur/postgres/postgres-deployment.yaml`, `bases/augur/postgres/postgres-pvc.yaml`, `bases/augur/postgres/postgres-svc.yaml`, `bases/augur/rabbitmq/rabbitmq-config-secret.yaml`) [[1]](diffhunk://#diff-5fee0d126e7786c13f513d11b4307b365fe02ffcb0c08763910510521941cd62R1-R73) [[2]](diffhunk://#diff-e59f859710b1fac0ddd5935bf40b4f27d91af66473e3b50b69d26b399ede6751R1-R11) [[3]](diffhunk://#diff-c5ea2151fb758867813cb67ffac025b8953271866d1c608daa5b1e02f666539eR1-R11) [[4]](diffhunk://#diff-4367469d3b3c69f487b8b89ab799c91c3724d56cea9fb29fa99a96148b610f31R1-R11) [[5]](diffhunk://#diff-baf92bf46d46c74cfc257e1981b3f371413389eddf729784606ad123c436dd9bR1-R27) [[6]](diffhunk://#diff-2005f8f11d8585ed68aa75381bae8fb8691490a562475c0b53b44785605d3bc7R1-R13) [[7]](diffhunk://#diff-feecd96c0277e152e635d7b323401962adacaa08eea4b1856f1e8d792d1c0570R1-R18) [[8]](diffhunk://#diff-354e782ec94ecfc5ffb8d8593dd1639c950920e258f4a4f12b43e94331aad435R1-R37) [[9]](diffhunk://#diff-fc02a24e6202549a3fe5048d5a2c8ec7928b6616f36f69ae40edd733e5ed59feR1-R11) [[10]](diffhunk://#diff-bd0821f96e7527483579ad86c110e8115804d53986f8cd31f999704ab54a2a33R1-R12) [[11]](diffhunk://#diff-e2c9a64edbda78924ef87f2fbfa320ddcac9f53dcf7506df6359715dcae58ab6R1-R30)

* Added `kustomization.yaml` files for each component to manage Kubernetes resources and apply consistent labels. (`bases/augur/backend/kustomization.yaml`, `bases/augur/flower/kustomization.yaml`, `bases/augur/keyman/kustomization.yaml`, `bases/augur/kustomization.yaml`, `bases/augur/postgres/kustomization.yaml`, `bases/augur/rabbitmq/kustomization.yaml`) [[1]](diffhunk://#diff-6438f651177d2561a015519750ad7abe9a775930d7c84c6441d2c551133c0732R1-R15) [[2]](diffhunk://#diff-f849486cef96a088ecc3dc8c4a278510ad3d98de02e032d5cd07c927778ea318R1-R13) [[3]](diffhunk://#diff-450fd6efade03bbf7bea094c29b28e73f8dfb56d74e47dba7a30235eca072cf1R1-R12) [[4]](diffhunk://#diff-7c7d0b898b7e96a72311f1267e8d082710600f90c72edbb8ee71e34585740cc0R1-R16) [[5]](diffhunk://#diff-82b4ab4ec176e545aba9ee42f7fc4216bfe34a73541267e4b8a04e064cdad7ccR1-R15) [[6]](diffhunk://#diff-d70ac0f4ddbd0ba45086cb3de2832674776d891d54bd732334ebf595ed1d5534R1-R14)

### YAML Linting Configuration:
* Disabled the `line-length` rule in the YAML linting configuration to allow longer lines, particularly for inline mappings. (`.github/yamllint-config.yaml`)

### Development Environment Updates:
* Updated `.devcontainer/devcontainer.json` to add a new step for installing `xdg-utils` and reformatted existing commands for better readability. (`.devcontainer/devcontainer.json`)