### PR TITLE
Don't pin container images

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -4,7 +4,7 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended", // Use recommended settings
-    "docker:pinDigests", // Pin container digests
+    // "docker:pinDigests", // Pin container digests
     "helpers:pinGitHubActionDigests", // Pin GitHub action digests
     ":enablePreCommit", // Enable updates to pre-commit repos
     ":gitSignOff", // Add Signed-off-by line to commit messages

--- a/deploy/kustomization.yaml
+++ b/deploy/kustomization.yaml
@@ -19,7 +19,7 @@ namespace: augur-on-ocp
 images:
   - name: ghcr.io/chaoss/augur_backend
     newName: johnstrunk/augur-backend
-    newTag: latest@sha256:a2eb5a3d6797552cb299ab650acb4abcfb2d3ea5b590dfb0dfd8db8f305406fd
+    newTag: latest
   - name: ghcr.io/chaoss/augur_keyman
     newName: johnstrunk/augur-keyman
-    newTag: latest@sha256:85d8546c0cba7ff9780c82c4d57c88445a2657e6b31252c342f5e24ca05671dc
+    newTag: latest


### PR DESCRIPTION
This pull request includes updates to configuration files to modify container image handling and renovate settings. The most significant changes involve unpinning container image digests and commenting out a specific renovate configuration.

### Updates to container image handling:

* [`deploy/kustomization.yaml`](diffhunk://#diff-b73d35871b29b22f3a3720154ad3b1f40bbd6ac482b4a4fdee49c0ad75a149dbL22-R25): Removed pinned container image digests (`sha256` values) for `augur_backend` and `augur_keyman` images, leaving only the `latest` tag. This change simplifies image management by relying on the `latest` tag instead of specific digests.

### Updates to renovate settings:

* [`.github/renovate.json5`](diffhunk://#diff-20ab1190d08a53a3012bc191ed56205c8f0ffb8fa1715e9d36ecfd1d2ea8a790L7-R7): Commented out the `"docker:pinDigests"` configuration, which previously ensured container digests were pinned. This change aligns with the decision to unpin digests in the deployment configuration.