### PR TITLE
Add valkey

### DIFF
--- a/bases/augur/kustomization.yaml
+++ b/bases/augur/kustomization.yaml
@@ -9,6 +9,7 @@ resources:
   - postgres-operator
   - rabbitmq-operator
   - redis
+  - valkey
 
 labels:
   - includeTemplates: true

--- a/bases/augur/valkey/kustomization.yaml
+++ b/bases/augur/valkey/kustomization.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - valkey-configmap.yaml
+  - valkey-services.yaml
+  - valkey-statefulset.yaml
+
+labels:
+  - includeSelectors: true
+    pairs:
+      app.kubernetes.io/component: valkey
+      app.kubernetes.io/name: augur-valkey

--- a/bases/augur/valkey/valkey-configmap.yaml
+++ b/bases/augur/valkey/valkey-configmap.yaml
@@ -1,0 +1,35 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: valkey-config
+data:
+  valkey.conf: |
+    # Listen on all container interfaces
+    bind 0.0.0.0
+    port 6379
+
+    # Enable persistence
+    appendonly yes
+
+    # Set data directory
+    dir /data
+
+  sentinel.conf: |
+    # Sentinel will listen on its standard port
+    port 26379
+
+    # Tell Sentinel to monitor the master group "mycluster".
+    # The master is initially valkey-0.valkey-headless.
+    # The quorum of "2" means at least two Sentinels must agree
+    # before a failover is initiated.
+    sentinel monitor mycluster valkey-0.valkey-headless 6379 2
+
+    # Time in ms after which a master is considered down
+    sentinel down-after-milliseconds mycluster 5000
+
+    # Number of replicas that can sync with a new master at once
+    sentinel parallel-syncs mycluster 1
+
+    # Timeout for the failover process itself in ms
+    sentinel failover-timeout mycluster 15000

--- a/bases/augur/valkey/valkey-services.yaml
+++ b/bases/augur/valkey/valkey-services.yaml
@@ -1,0 +1,42 @@
+---
+# Headless service for DNS discovery among pods in the StatefulSet
+apiVersion: v1
+kind: Service
+metadata:
+  name: valkey-headless
+spec:
+  clusterIP: None
+  selector:
+    app: valkey
+  ports:
+    - name: valkey
+      port: 6379
+      targetPort: 6379
+
+# ---
+# # Standard service for read-only clients, load-balances across all pods
+# apiVersion: v1
+# kind: Service
+# metadata:
+#   name: valkey-read
+# spec:
+#   selector:
+#     app: valkey
+#   ports:
+#     - name: valkey
+#       port: 6379
+#       targetPort: 6379
+
+---
+# Service for clients to discover and connect to the Sentinels
+apiVersion: v1
+kind: Service
+metadata:
+  name: valkey-sentinel
+spec:
+  selector:
+    app: valkey
+  ports:
+    - name: sentinel
+      port: 26379
+      targetPort: 26379

--- a/bases/augur/valkey/valkey-statefulset.yaml
+++ b/bases/augur/valkey/valkey-statefulset.yaml
@@ -1,0 +1,99 @@
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: valkey
+spec:
+  serviceName: valkey-headless
+  replicas: 3
+  selector:
+    matchLabels:
+      app: valkey
+  template:
+    metadata:
+      labels:
+        app: valkey
+    spec:
+      containers:
+        - name: valkey
+          image: valkey/valkey:7.2
+          env:
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          command:
+            - "sh"
+            - "-c"
+            - |
+              if [ "$(hostname)" = "valkey-0" ]; then
+                # The primary starts without being a replica.
+                valkey-server /etc/valkey/valkey.conf
+              else
+                # Replicas must resolve the primary's FQDN to an IP address first.
+                MASTER_FQDN="valkey-0.valkey-headless.${POD_NAMESPACE}.svc.cluster.local"
+                echo "Replica waiting for primary DNS: ${MASTER_FQDN}"
+                until getent hosts ${MASTER_FQDN}; do sleep 1; done
+
+                MASTER_IP=$(getent hosts ${MASTER_FQDN} | awk '{ print $1 }')
+                echo "Replica found primary at IP: ${MASTER_IP}"
+
+                # Start as a replica using the resolved IP address.
+                valkey-server /etc/valkey/valkey.conf --replicaof ${MASTER_IP} 6379
+              fi
+          ports:
+            - name: valkey
+              containerPort: 6379
+          volumeMounts:
+            - name: config
+              mountPath: /etc/valkey
+            - name: data
+              mountPath: /data
+        - name: sentinel
+          image: valkey/valkey:7.2
+          env:
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          command:
+            - "sh"
+            - "-c"
+            - |
+              MASTER_FQDN="valkey-0.valkey-headless.${POD_NAMESPACE}.svc.cluster.local"
+              CONFIG_TEMPLATE="/etc/valkey/sentinel.conf"
+              RUNTIME_CONFIG="/tmp/sentinel.conf"
+
+              echo "Waiting for DNS record for ${MASTER_FQDN}..."
+              until getent hosts ${MASTER_FQDN}; do sleep 1; done
+
+              # Resolve the FQDN to an IP and store it.
+              MASTER_IP=$(getent hosts ${MASTER_FQDN} | awk '{ print $1 }')
+              echo "DNS record found for ${MASTER_FQDN} -> ${MASTER_IP}"
+
+              # Create a new config file using the IP address instead of the hostname.
+              sed "s/valkey-0.valkey-headless/${MASTER_IP}/" "${CONFIG_TEMPLATE}" > "${RUNTIME_CONFIG}"
+
+              echo "Sentinel runtime configuration using IP address:"
+              cat "${RUNTIME_CONFIG}"
+
+              # Start Sentinel with the IP-based config file.
+              valkey-sentinel "${RUNTIME_CONFIG}"
+          ports:
+            - name: sentinel
+              containerPort: 26379
+          volumeMounts:
+            - name: config
+              mountPath: /etc/valkey
+      volumes:
+        - name: config
+          configMap:
+            name: valkey-config
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        resources:
+          requests:
+            storage: 1Gi


### PR DESCRIPTION
This pull request introduces a new `valkey` component to the `augur` base configuration. The `valkey` component is designed as a Redis-like service with high availability, using StatefulSets and Sentinel for failover and replication. The changes include updates to the `kustomization.yaml` files and the addition of several Kubernetes resource definitions for `valkey`.

### Addition of the `valkey` component:

* **Integration into `augur` base configuration**:
  - Added `valkey` to the `resources` list in `bases/augur/kustomization.yaml`, enabling its inclusion in the overall `augur` deployment.

* **New `valkey` component configuration**:
  - Created `bases/augur/valkey/kustomization.yaml` to define the resources and labels for the `valkey` component. This includes references to the `ConfigMap`, `Services`, and `StatefulSet` for `valkey`.

### Kubernetes resource definitions for `valkey`:

* **Configuration management**:
  - Added `bases/augur/valkey/valkey-configmap.yaml` to define configurations for `valkey` and its Sentinel, including persistence settings, replication parameters, and failover behavior.

* **Service definitions**:
  - Added `bases/augur/valkey/valkey-services.yaml` to define Kubernetes services for `valkey`, including a headless service for DNS-based discovery and a Sentinel service for failover coordination.

* **StatefulSet for high availability**:
  - Added `bases/augur/valkey/valkey-statefulset.yaml` to define the `valkey` StatefulSet with three replicas, DNS-based primary discovery, and Sentinel runtime configuration for failover monitoring.