### PR TITLE
Add valkey PDB and readiness probes

### DIFF
--- a/bases/augur/valkey/kustomization.yaml
+++ b/bases/augur/valkey/kustomization.yaml
@@ -4,6 +4,7 @@ kind: Kustomization
 
 resources:
   - valkey-configmap.yaml
+  - valkey-pdb.yaml
   - valkey-services.yaml
   - valkey-statefulset.yaml
 

--- a/bases/augur/valkey/valkey-pdb.yaml
+++ b/bases/augur/valkey/valkey-pdb.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: valkey-pdb
+spec:
+  minAvailable: 2  # To maintain quorum, at least 2 pods must be available
+  selector:
+    matchLabels:
+      app: valkey

--- a/bases/augur/valkey/valkey-statefulset.yaml
+++ b/bases/augur/valkey/valkey-statefulset.yaml
@@ -44,6 +44,15 @@ spec:
           ports:
             - name: valkey
               containerPort: 6379
+          readinessProbe:
+            exec:
+              command:
+                - valkey-cli
+                - PING
+            initialDelaySeconds: 10
+            periodSeconds: 5
+            timeoutSeconds: 2
+            failureThreshold: 3
           volumeMounts:
             - name: config
               mountPath: /etc/valkey
@@ -82,9 +91,31 @@ spec:
           ports:
             - name: sentinel
               containerPort: 26379
+          readinessProbe:
+            exec:
+              command:
+                - valkey-cli
+                - -p
+                - "26379"
+                - PING
+            initialDelaySeconds: 15
+            periodSeconds: 5
+            timeoutSeconds: 2
+            failureThreshold: 3
           volumeMounts:
             - name: config
               mountPath: /etc/valkey
+      topologySpreadConstraints:
+        - maxSkew: 1
+          # This key is used to ensure instances are spread across failure domains
+          # kubernetes.io/hostname spreads instances across nodes
+          # topology.kubernetes.io/zone spreads instances across zones w/in a region
+          # topology.kubernetes.io/region spreads instances across regions
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: DoNotSchedule
+          labelSelector:
+            matchLabels:
+              app: valkey
       volumes:
         - name: config
           configMap:


### PR DESCRIPTION
This pull request introduces several updates to improve the reliability and availability of the `valkey` application. Key changes include adding a PodDisruptionBudget to ensure quorum, implementing readiness probes for better pod health checks, and defining topology spread constraints to enhance fault tolerance.

### Enhancements to reliability and availability:

* **PodDisruptionBudget added**: Introduced `valkey-pdb.yaml` to ensure at least two pods remain available during disruptions, maintaining quorum. (`bases/augur/valkey/valkey-pdb.yaml`)
* **Readiness probes implemented**:
  - Added a readiness probe for the main `valkey` container on port 6379 to verify pod health using `valkey-cli PING`. (`bases/augur/valkey/valkey-statefulset.yaml`)
  - Added a readiness probe for the `sentinel` container on port 26379 with similar health checks. (`bases/augur/valkey/valkey-statefulset.yaml`)

### Improvements to fault tolerance:

* **Topology spread constraints defined**: Configured constraints to distribute `valkey` instances across nodes and zones, reducing the risk of downtime due to localized failures. (`bases/augur/valkey/valkey-statefulset.yaml`)

### Supporting changes:

* **Resource inclusion**: Updated `kustomization.yaml` to include the new PodDisruptionBudget resource. (`bases/augur/valkey/kustomization.yaml`)